### PR TITLE
chore(maths): use doctest to test docstring example

### DIFF
--- a/maths.py
+++ b/maths.py
@@ -1,34 +1,58 @@
 def add(a, b):
-    """ Compute the sum of two numbers """
+    """
+    Compute the sum of two numbers
+
+    >>> add(1, 2)
+    3
+    >>> add(1, 0)
+    1
+    >>> add(-2, 1)
+    -1
+    """
     return a + b
 
 def div(a, b):
-    """ Compute the quotient of two numbers """
+    """
+    Compute the quotient of two numbers
+
+    >>> div(6, 2)
+    3.0
+    >>> div(3, -1)
+    -3.0
+    """
     if b == 0:
         raise DivisionByZeroError()
     return a / b
 
 def mul(a, b):
-    """ Compute the product of two numbers """
+    """
+    Compute the product of two numbers
+
+    >>> mul(3, 2)
+    6
+    >>> mul(3, 0)
+    0
+    >>> mul(-1, 5)
+    -5
+    """
     m = 0
     for _ in range(b):
         m += a
     return m
 
 def sub(a, b):
-    """ Compute the difference of two numbers """
+    """
+    Compute the difference of two numbers
+
+    >>> sub(1, 2)
+    -1
+    >>> sub(2, 1)
+    1
+    >>> sub(1, 0)
+    1
+    """
     return a - b
 
 if __name__ == '__main__':
-    assert add(1, 2) == 3
-    assert add(1, 0) == 1
-    assert add(-2, 1) == -1
-    assert div(6, 2) == 3
-    assert div(3, -1) == -3
-    assert mul(3, 2) == 6
-    assert mul(3, 0) == 0
-    assert mul(-1, 5) == -5
-    assert sub(1, 2) == -1
-    assert sub(2, 1) == 1
-    assert sub(1, 0) == 1
-    print("ok")
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
The doctest[^1] module is a special library available in the standard library of python that can be used to evaluate example snippets inside of function docstrings. Because most of our tests are very simple and would be great examples of how to use the functions they test, we decided to change `assert` for `doctest`.

In the following example:

    def foo():
        """
        Compute the square root of 25.

        >>> foo()
        5
        """
        return 5

Doctest is going to execute `foo()` and it verifies that the function returns `5`. Any text that precedes the first example (noted by `>>>`) is ignored.

[^1]: https://pymotw.com/3/doctest/